### PR TITLE
chore: rm blockchain category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ keywords = [
     "cryptography",
 ]
 categories = [
-    "blockchain",
     "cryptography"
 ]
 repository = "https://github.com/wavesplatform/waves-rust"


### PR DESCRIPTION
 rm blockchain category due to category slugs are not currently supported on crates.io